### PR TITLE
simplify signed packed integer reading (o5m)

### DIFF
--- a/de/kumakyoo/oma/PackedIntegerReader.java
+++ b/de/kumakyoo/oma/PackedIntegerReader.java
@@ -23,28 +23,10 @@ abstract public class PackedIntegerReader extends OSMReader
 
     protected long s(DataInputStream in) throws IOException
     {
-        long val = 0;
-        long fak = 1;
-        boolean first = true;
-        boolean sign = false;
+        long val = u(in);
+        boolean sign = (val&0x01)==0x01;
 
-        while (true)
-        {
-            int next = in.readUnsignedByte();
-
-            if (first)
-            {
-                sign = (next&0x01)==0x01;
-                next = (next&0x80) + ((next&0x7f)>>1);
-            }
-
-            val += (next&0x7f)*fak;
-            if (next<0x80) break;
-
-            fak *= first?0x40:0x80;
-
-            first = false;
-        }
+        val >>= 1;
         return sign?(-val-1):val;
     }
 }


### PR DESCRIPTION
I think the logic should be the same, but please verify it on your end as well.

In my opinion, this reduces complexity of this code piece a lot, but if you don't want the signed reading to depend on the unsigned one, feel free to close this.